### PR TITLE
Fixed fillU

### DIFF
--- a/script.js
+++ b/script.js
@@ -122,7 +122,7 @@ function fill(){
 }
 
 function clearAll(){
-    alert("Clicked Clear All")
+    //alert("Clicked Clear All")
     let rows = document.getElementsByTagName("tr");
     let cols = document.getElementsByTagName("td");
     for (let row of rows) {


### PR DESCRIPTION
Prior to this, fillU only worked when you cleared all, which would set backgroundColor to transparent,. However, without clear all it is set to empty ("").